### PR TITLE
finer-grained temperature control, properly set unit of AC's LED display

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -16,7 +16,7 @@ from homeassistant.components.climate import ClimateDevice, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
     SUPPORT_PRESET_MODE, PRESET_NONE, PRESET_ECO, PRESET_BOOST)
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, TEMP_CELSIUS, \
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, TEMP_CELSIUS, TEMP_FAHRENHEIT, \
     ATTR_TEMPERATURE
 
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -79,6 +79,8 @@ class MideaClimateACDevice(ClimateDevice, RestoreEntity):
         if include_off_as_state:
             self._operation_list.append("off")
         self._support_flags = SUPPORT_FLAGS
+        #the LED display on the AC should use the same unit as that in homeassistant
+        device.farenheit_unit = (hass.config.units.temperature_unit == TEMP_FAHRENHEIT)
         self._device = device
         self._unit_of_measurement = TEMP_CELSIUS
         self._target_temperature_step = temp_step

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -232,7 +232,7 @@ class MideaClimateACDevice(ClimateDevice, RestoreEntity):
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
         if kwargs.get(ATTR_TEMPERATURE) is not None:
-            self._device.target_temperature = int(kwargs.get(ATTR_TEMPERATURE))
+            self._device.target_temperature = (kwargs.get(ATTR_TEMPERATURE))
             self._changed = True
             await self.apply_changes()
 


### PR DESCRIPTION
if home assistant is configured to use Fahrenheit unit, this enables setting of target temperature upto 1F resolution instead of 2F resolution. 
No advantage currently in Celcius mode, but `temp_step` should be changed to `0.5` to exploit the full capabilities of many devices: the api certainly allows 0.5C resolution.
depends on https://github.com/mac-zhou/midea-msmart/pull/9