### PR TITLE
Add support for device registration, GUI configuration flow and additional sensor entities

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -1,24 +1,20 @@
 """Integration for Midea Smart AC."""
 from __future__ import annotations
 
-from homeassistant.core import HomeAssistant
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.config_entries import ConfigEntry
-
-import logging
+from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+from homeassistant.core import HomeAssistant
 from msmart.device import air_conditioning as ac
 
-# Local consts
+# Local constants
 from .const import (
     DOMAIN,
     CONF_K1
 )
 
-_LOGGER = logging.getLogger(__name__)
 
-
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
-    """Set up a Midea AC device entry."""
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up a Midea AC device from a config entry."""
 
     # Ensure the global data dict exists
     hass.data.setdefault(DOMAIN, {})
@@ -52,10 +48,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, "sensor"))
 
+    # Reload entry when its updated
+    config_entry.async_on_unload(
+        config_entry.add_update_listener(async_reload_entry))
+
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
 
     # Get config data from entry
     config = config_entry.data
@@ -68,3 +68,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
 
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(config_entry.entry_id)

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
-from homeassistant.helpers import device_registry as dr
 from homeassistant.config_entries import ConfigEntry
 
 import logging
 from msmart.device import air_conditioning as ac
-import voluptuous as vol
 
 # Local consts
 from .const import (
@@ -21,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Set up a Midea AC device entry."""
-    
+
     # Ensure the global data dict exists
     hass.data.setdefault(DOMAIN, {})
 
@@ -53,5 +51,20 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         hass.config_entries.async_forward_entry_setup(config_entry, "climate"))
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, "sensor"))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+
+    # Get config data from entry
+    config = config_entry.data
+
+    # Remove device from global data
+    id = config.get(CONF_ID)
+    hass.data[DOMAIN].pop(id)
+
+    await hass.config_entries.async_forward_entry_unload(config_entry, "climate")
+    await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
 
     return True

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -1,11 +1,10 @@
 """Integration for Midea Smart AC."""
 from __future__ import annotations
 
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.config_entries import ConfigEntry
 
 import logging
 from msmart.device import air_conditioning as ac
@@ -14,66 +13,45 @@ import voluptuous as vol
 # Local consts
 from .const import (
     DOMAIN,
-    CONF_K1,
-    CONF_PROMPT_TONE,
-    CONF_TEMP_STEP,
-    CONF_INCLUDE_OFF_AS_STATE,
-    CONF_USE_FAN_ONLY_WORKAROUND,
-    CONF_KEEP_LAST_KNOWN_ONLINE_STATE
+    CONF_K1
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_ID): cv.string,
-                vol.Required(CONF_HOST): cv.string,
-                vol.Optional(CONF_PORT, default=6444): vol.Coerce(int),
-                vol.Optional(CONF_TOKEN, default=""): cv.string,
-                vol.Optional(CONF_K1, default=""): cv.string,
-                vol.Optional(CONF_PROMPT_TONE, default=True): vol.Coerce(bool),
-                vol.Optional(CONF_TEMP_STEP, default=1.0): vol.Coerce(float),
-                vol.Optional(CONF_INCLUDE_OFF_AS_STATE, default=True): vol.Coerce(bool),
-                vol.Optional(CONF_USE_FAN_ONLY_WORKAROUND, default=False): vol.Coerce(bool),
-                vol.Optional(CONF_KEEP_LAST_KNOWN_ONLINE_STATE, default=False): vol.Coerce(bool)
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA
-)
 
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Set up a Midea AC device entry."""
+    
+    # Ensure the global data dict exists
+    hass.data.setdefault(DOMAIN, {})
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the connection to Midea device."""
+    # Get config data from entry
+    config = config_entry.data
 
-    # Fetch domain config
-    config = config[DOMAIN]
-
-    # Construct the device
+    # Attempt to get device from global data
     id = config.get(CONF_ID)
-    host = config.get(CONF_HOST)
-    port = config.get(CONF_PORT)
-    device = ac(host, int(id), port)
+    device = hass.data[DOMAIN].get(id)
 
-    # Configure token and k1 as needed
-    token = config.get(CONF_TOKEN)
-    k1 = config.get(CONF_K1)
-    if token and k1:
-        device._protocol_version = 3
-        device._token = bytearray.fromhex(token)
-        device._key = bytearray.fromhex(k1)
-        device._lan_service._token = device._token
-        device._lan_service._key = device._key
+    # Construct a new device if necessary
+    if device is None:
+        # Construct the device
+        id = config.get(CONF_ID)
+        host = config.get(CONF_HOST)
+        port = config.get(CONF_PORT)
+        device = ac(host, int(id), port)
 
-    # Save the device for our platforms
-    hass.data[DOMAIN] = {
-        "device": device
-    }
+        # Configure token and k1 as needed
+        token = config.get(CONF_TOKEN)
+        k1 = config.get(CONF_K1)
+        if token and k1:
+            await hass.async_add_executor_job(device.authenticate, k1, token)
 
-    # Load the platforms
-    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform("climate", DOMAIN, {}, config)
+        hass.data[DOMAIN][id] = device
+
+    # Create platform entries
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "climate"))
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "sensor"))
 
     return True

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -1,0 +1,79 @@
+"""Integration for Midea Smart AC."""
+from __future__ import annotations
+
+from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.typing import ConfigType
+
+import logging
+from msmart.device import air_conditioning as ac
+import voluptuous as vol
+
+# Local consts
+from .const import (
+    DOMAIN,
+    CONF_K1,
+    CONF_PROMPT_TONE,
+    CONF_TEMP_STEP,
+    CONF_INCLUDE_OFF_AS_STATE,
+    CONF_USE_FAN_ONLY_WORKAROUND,
+    CONF_KEEP_LAST_KNOWN_ONLINE_STATE
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_ID): cv.string,
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_PORT, default=6444): vol.Coerce(int),
+                vol.Optional(CONF_TOKEN, default=""): cv.string,
+                vol.Optional(CONF_K1, default=""): cv.string,
+                vol.Optional(CONF_PROMPT_TONE, default=True): vol.Coerce(bool),
+                vol.Optional(CONF_TEMP_STEP, default=1.0): vol.Coerce(float),
+                vol.Optional(CONF_INCLUDE_OFF_AS_STATE, default=True): vol.Coerce(bool),
+                vol.Optional(CONF_USE_FAN_ONLY_WORKAROUND, default=False): vol.Coerce(bool),
+                vol.Optional(CONF_KEEP_LAST_KNOWN_ONLINE_STATE, default=False): vol.Coerce(bool)
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the connection to Midea device."""
+
+    # Fetch domain config
+    config = config[DOMAIN]
+
+    # Construct the device
+    id = config.get(CONF_ID)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    device = ac(host, int(id), port)
+
+    # Configure token and k1 as needed
+    token = config.get(CONF_TOKEN)
+    k1 = config.get(CONF_K1)
+    if token and k1:
+        device._protocol_version = 3
+        device._token = bytearray.fromhex(token)
+        device._key = bytearray.fromhex(k1)
+        device._lan_service._token = device._token
+        device._lan_service._key = device._key
+
+    # Save the device for our platforms
+    hass.data[DOMAIN] = {
+        "device": device
+    }
+
+    # Load the platforms
+    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    hass.helpers.discovery.load_platform("climate", DOMAIN, {}, config)
+
+    return True

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -130,6 +130,8 @@ class MideaClimateACDevice(ClimateEntity, RestoreEntity):
             "identifiers": {
                 (DOMAIN, self._device.id)
             },
+            "name": self.name,
+            "manufacturer": "Midea",
         }
 
     @property

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -181,7 +181,7 @@ class MideaClimateACDevice(ClimateEntity, RestoreEntity):
     @property
     def name(self):
         """Return the name of the climate device."""
-        return "midea_{:2x}_{}".format(self._device._type, self._device.id)
+        return f"{DOMAIN}_{self._device.id}"
 
     @property
     def temperature_unit(self):

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -39,7 +39,7 @@ class MideaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.hass.data.setdefault(DOMAIN, {})
                 self.hass.data[DOMAIN][id] = device
                 # Create a setup entry with all the config data
-                return self.async_create_entry(title=device.name, data=config)
+                return self.async_create_entry(title=f"{DOMAIN} {id}", data=config)
             else:
                 errors["base"] = "connection"
 

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -61,17 +61,30 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Indicate a connection could not be made
                 errors["base"] = "cannot_connect"
 
+        
+        user_input = user_input or {}
+        
         data_schema = vol.Schema({
-            vol.Required(CONF_ID): cv.string,
-            vol.Required(CONF_HOST): cv.string,
-            vol.Optional(CONF_PORT, default=6444): cv.port,
-            vol.Optional(CONF_TOKEN, default=""): cv.string,
-            vol.Optional(CONF_K1, default=""): cv.string,
-            vol.Optional(CONF_PROMPT_TONE, default=True): cv.boolean,
-            vol.Optional(CONF_TEMP_STEP, default=1.0): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=5)),
-            vol.Optional(CONF_INCLUDE_OFF_AS_STATE, default=True): cv.boolean,
-            vol.Optional(CONF_USE_FAN_ONLY_WORKAROUND, default=False):  cv.boolean,
-            vol.Optional(CONF_KEEP_LAST_KNOWN_ONLINE_STATE, default=False):  cv.boolean
+            vol.Required(CONF_ID,
+                         default=user_input.get(CONF_ID)): cv.string,
+            vol.Required(CONF_HOST,
+                         default=user_input.get(CONF_HOST)): cv.string,
+            vol.Optional(CONF_PORT,
+                         default=user_input.get(CONF_PORT, 6444)): cv.port,
+            vol.Optional(CONF_TOKEN,
+                         default=user_input.get(CONF_TOKEN, "")): cv.string,
+            vol.Optional(CONF_K1,
+                         default=user_input.get(CONF_K1, "")): cv.string,
+            vol.Optional(CONF_PROMPT_TONE,
+                         default=user_input.get(CONF_PROMPT_TONE, True)): cv.boolean,
+            vol.Optional(CONF_TEMP_STEP,
+                         default=user_input.get(CONF_TEMP_STEP, 1.0)): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=5)),
+            vol.Optional(CONF_INCLUDE_OFF_AS_STATE,
+                         default=user_input.get(CONF_INCLUDE_OFF_AS_STATE, True)): cv.boolean,
+            vol.Optional(CONF_USE_FAN_ONLY_WORKAROUND,
+                         default=user_input.get(CONF_USE_FAN_ONLY_WORKAROUND, False)):  cv.boolean,
+            vol.Optional(CONF_KEEP_LAST_KNOWN_ONLINE_STATE,
+                         default=user_input.get(CONF_KEEP_LAST_KNOWN_ONLINE_STATE, False)):  cv.boolean
         })
 
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -23,7 +23,7 @@ from .const import (
 
 class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
-    async def async_step_user(self, user_input):
+    async def async_step_user(self, user_input) -> FlowResult:
         errors = {}
         if user_input is not None:
             # Set the unique ID and abort if duplicate exists
@@ -76,7 +76,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
 
-    async def _test_connection(self, config):
+    async def _test_connection(self, config) -> ac | None:
         # Construct the device
         id = config.get(CONF_ID)
         host = config.get(CONF_HOST)
@@ -101,6 +101,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class MideaOptionsFlow(OptionsFlow):
+
     def __init__(self, config_entry: ConfigEntry) -> None:
         self.config_entry = config_entry
 

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -1,0 +1,77 @@
+"""Config flow for Midea Smart AC."""
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+import homeassistant.helpers.config_validation as cv
+
+import voluptuous as vol
+from msmart.device import air_conditioning as ac
+
+# Local consts
+from .const import (
+    DOMAIN,
+    CONF_K1,
+    CONF_PROMPT_TONE,
+    CONF_TEMP_STEP,
+    CONF_INCLUDE_OFF_AS_STATE,
+    CONF_USE_FAN_ONLY_WORKAROUND,
+    CONF_KEEP_LAST_KNOWN_ONLINE_STATE
+)
+
+class MideaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+
+    async def async_step_user(self, config):
+        errors = {}
+        if config is not None:
+            # Fetch ID from the user
+            id = config.get(CONF_ID)
+
+            # Set the unique ID and allow updates to host and port
+            await self.async_set_unique_id(id)
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: config.get(CONF_HOST), CONF_PORT: config.get(CONF_PORT)})
+
+            # Attempt to verify the user settings
+            device = await self._test_connection(config)
+
+            if device:
+                # Save the device into global data
+                self.hass.data.setdefault(DOMAIN, {})
+                self.hass.data[DOMAIN][id] = device
+                # Create a setup entry with all the config data
+                return self.async_create_entry(title=device.name, data=config)
+            else:
+                errors["base"] = "connection"
+
+        data_schema = vol.Schema({
+            vol.Required(CONF_ID): cv.string,
+            vol.Required(CONF_HOST): cv.string,
+            vol.Optional(CONF_PORT, default=6444): cv.port,
+            vol.Optional(CONF_TOKEN, default=""): cv.string,
+            vol.Optional(CONF_K1, default=""): cv.string,
+            vol.Optional(CONF_PROMPT_TONE, default=True): cv.boolean,
+            vol.Optional(CONF_TEMP_STEP, default=1.0): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=5)),
+            vol.Optional(CONF_INCLUDE_OFF_AS_STATE, default=True): cv.boolean,
+            vol.Optional(CONF_USE_FAN_ONLY_WORKAROUND, default=False):  cv.boolean,
+            vol.Optional(CONF_KEEP_LAST_KNOWN_ONLINE_STATE, default=False):  cv.boolean
+        })
+
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def _test_connection(self, config):
+        # Construct the device
+        id = config.get(CONF_ID)
+        host = config.get(CONF_HOST)
+        port = config.get(CONF_PORT)
+        device = ac(host, int(id), port)
+
+        # Configure token and k1 as needed
+        token = config.get(CONF_TOKEN)
+        k1 = config.get(CONF_K1)
+        if token and k1:
+            success = await self.hass.async_add_executor_job(device.authenticate, k1, token)
+        else:
+            await self.hass.async_add_executor_job(device.refresh)
+            success = device.online
+
+        return device if success else None

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -1,13 +1,15 @@
 """Config flow for Midea Smart AC."""
+from __future__ import annotations
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
-
-import voluptuous as vol
 from msmart.device import air_conditioning as ac
+import voluptuous as vol
 
-# Local consts
+# Local constants
 from .const import (
     DOMAIN,
     CONF_K1,
@@ -18,30 +20,46 @@ from .const import (
     CONF_KEEP_LAST_KNOWN_ONLINE_STATE
 )
 
-class MideaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
-    async def async_step_user(self, config):
+class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
+
+    async def async_step_user(self, user_input):
         errors = {}
-        if config is not None:
-            # Fetch ID from the user
-            id = config.get(CONF_ID)
-
-            # Set the unique ID and allow updates to host and port
+        if user_input is not None:
+            # Set the unique ID and abort if duplicate exists
+            id = user_input.get(CONF_ID)
             await self.async_set_unique_id(id)
-            self._abort_if_unique_id_configured(
-                updates={CONF_HOST: config.get(CONF_HOST), CONF_PORT: config.get(CONF_PORT)})
+            self._abort_if_unique_id_configured()
 
-            # Attempt to verify the user settings
-            device = await self._test_connection(config)
+            # Attempt a connection to see if config is valid
+            device = await self._test_connection(user_input)
 
             if device:
                 # Save the device into global data
                 self.hass.data.setdefault(DOMAIN, {})
                 self.hass.data[DOMAIN][id] = device
-                # Create a setup entry with all the config data
-                return self.async_create_entry(title=f"{DOMAIN} {id}", data=config)
+
+                # Split user input config data and options
+                data = {
+                    CONF_ID: id,
+                    CONF_HOST: user_input.get(CONF_HOST),
+                    CONF_PORT: user_input.get(CONF_PORT),
+                    CONF_TOKEN: user_input.get(CONF_TOKEN),
+                    CONF_K1: user_input.get(CONF_K1),
+                }
+                options = {
+                    CONF_PROMPT_TONE: user_input.get(CONF_PROMPT_TONE),
+                    CONF_TEMP_STEP: user_input.get(CONF_TEMP_STEP),
+                    CONF_INCLUDE_OFF_AS_STATE: user_input.get(CONF_INCLUDE_OFF_AS_STATE),
+                    CONF_USE_FAN_ONLY_WORKAROUND: user_input.get(CONF_USE_FAN_ONLY_WORKAROUND),
+                    CONF_KEEP_LAST_KNOWN_ONLINE_STATE: user_input.get(CONF_KEEP_LAST_KNOWN_ONLINE_STATE),
+                }
+
+                # Create a config entry with the config data and options
+                return self.async_create_entry(title=f"{DOMAIN} {id}", data=data, options=options)
             else:
-                errors["base"] = "connection"
+                # Indicate a connection could not be made
+                errors["base"] = "cannot_connect"
 
         data_schema = vol.Schema({
             vol.Required(CONF_ID): cv.string,
@@ -75,3 +93,35 @@ class MideaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             success = device.online
 
         return device if success else None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        return MideaOptionsFlow(config_entry)
+
+
+class MideaOptionsFlow(OptionsFlow):
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        if user_input is not None:
+            # Confusingly, data argument in OptionsFlow is passed to async_setup_entry in the options member
+            return self.async_create_entry(title="", data=user_input)
+
+        options = self.config_entry.options
+
+        data_schema = vol.Schema({
+            vol.Optional(CONF_PROMPT_TONE,
+                         default=options.get(CONF_PROMPT_TONE, True)): cv.boolean,
+            vol.Optional(CONF_TEMP_STEP,
+                         default=options.get(CONF_TEMP_STEP, 1.0)): vol.All(vol.Coerce(float), vol.Range(min=0.5, max=5)),
+            vol.Optional(CONF_INCLUDE_OFF_AS_STATE,
+                         default=options.get(CONF_INCLUDE_OFF_AS_STATE, True)): cv.boolean,
+            vol.Optional(CONF_USE_FAN_ONLY_WORKAROUND,
+                         default=options.get(CONF_USE_FAN_ONLY_WORKAROUND, False)):  cv.boolean,
+            vol.Optional(CONF_KEEP_LAST_KNOWN_ONLINE_STATE,
+                         default=options.get(CONF_KEEP_LAST_KNOWN_ONLINE_STATE, False)):  cv.boolean
+        })
+
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -1,8 +1,8 @@
 DOMAIN = "midea_ac"
 
 CONF_K1 = "k1"
-CONF_PROMPT_TONE = 'prompt_tone'
-CONF_TEMP_STEP = 'temp_step'
-CONF_INCLUDE_OFF_AS_STATE = 'include_off_as_state'
-CONF_USE_FAN_ONLY_WORKAROUND = 'use_fan_only_workaround'
-CONF_KEEP_LAST_KNOWN_ONLINE_STATE = 'keep_last_known_online_state'
+CONF_PROMPT_TONE = "prompt_tone"
+CONF_TEMP_STEP = "temp_step"
+CONF_INCLUDE_OFF_AS_STATE = "include_off_as_state"
+CONF_USE_FAN_ONLY_WORKAROUND = "use_fan_only_workaround"
+CONF_KEEP_LAST_KNOWN_ONLINE_STATE = "keep_last_known_online_state"

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -1,0 +1,8 @@
+DOMAIN = "midea_ac"
+
+CONF_K1 = "k1"
+CONF_PROMPT_TONE = 'prompt_tone'
+CONF_TEMP_STEP = 'temp_step'
+CONF_INCLUDE_OFF_AS_STATE = 'include_off_as_state'
+CONF_USE_FAN_ONLY_WORKAROUND = 'use_fan_only_workaround'
+CONF_KEEP_LAST_KNOWN_ONLINE_STATE = 'keep_last_known_online_state'

--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -1,6 +1,6 @@
 {
         "domain": "midea_ac",
-        "name": "Midea Smart Aircon",
+        "name": "Midea Smart AC",
         "version": "0.2.3",
         "documentation": "https://github.com/mac-zhou/midea-ac-py",
         "issue_tracker": "https://github.com/mac-zhou/midea-ac-py/issues",
@@ -8,5 +8,6 @@
         "dependencies": [],
         "codeowners": ["@mac-zhou"],
         "iot_class": "local_polling",
-        "config_flow": true
+        "config_flow": true,
+        "loggers": ["msmart"]
 }

--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -2,8 +2,11 @@
         "domain": "midea_ac",
         "name": "Midea Smart Aircon",
         "version": "0.2.3",
-        "documentation": "",
+        "documentation": "https://github.com/mac-zhou/midea-ac-py",
+        "issue_tracker": "https://github.com/mac-zhou/midea-ac-py/issues",
         "requirements": ["msmart==0.2.3", "pycryptodome", "pycryptodomex", "click"],
         "dependencies": [],
-        "codeowners": ["@mac-zhou"]
+        "codeowners": ["@mac-zhou"],
+        "iot_class": "local_polling",
+        "config_flow": true
 }

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -73,7 +73,7 @@ class MideaTemperatureSensor(RestoreSensor):
 
     @property
     def name(self) -> str:
-        return f"{DOMAIN}_{self._prop}"
+        return f"{DOMAIN}_{self._prop}_{self._device.id}"
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -19,7 +19,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     add_entities: AddEntitiesCallback,
-):
+) -> None:
     """Setup the sensor platform for Midea Smart AC."""
 
     _LOGGER.info("Setting up sensor platform.")
@@ -55,13 +55,13 @@ class MideaTemperatureSensor(RestoreSensor):
         # Restore previous native value
         self._native_value = last_sensor_data.native_value
 
-    async def async_update(self):
+    async def async_update(self) -> None:
         # Grab the property from the device
         if self.available:
             self._native_value = getattr(self._device, self._prop)
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict:
         return {
             "identifiers": {
                 (DOMAIN, self._device.id)
@@ -81,17 +81,17 @@ class MideaTemperatureSensor(RestoreSensor):
         return self._device.online
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         return SensorDeviceClass.TEMPERATURE
 
     @property
-    def state_class(self):
+    def state_class(self) -> str:
         return SensorStateClass.MEASUREMENT
 
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str:
         return TEMP_CELSIUS
 
     @property
-    def native_value(self):
+    def native_value(self) -> float:
         return self._native_value

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 import logging
 
-from . import DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +61,8 @@ class MideaTemperatureSensor(RestoreSensor):
 
     async def async_update(self):
         # Grab the property from the device
-        self._native_value = getattr(self._device, self._prop)
+        if self.available:
+            self._native_value = getattr(self._device, self._prop)
 
     @property
     def name(self) -> str:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -1,18 +1,15 @@
 """Platform for sensor integration."""
 from __future__ import annotations
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorStateClass,
-    RestoreSensor,
-)
-from homeassistant.const import TEMP_CELSIUS, CONF_ID
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.config_entries import ConfigEntry
-
 import logging
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import TEMP_CELSIUS, CONF_ID
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass, RestoreSensor
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+# Local constants
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -17,6 +17,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -25,7 +26,7 @@ async def async_setup_entry(
     """Setup the sensor platform for Midea Smart AC."""
 
     _LOGGER.info("Setting up sensor platform.")
-    
+
     # Get config data from entry
     config = config_entry.data
 
@@ -35,18 +36,16 @@ async def async_setup_entry(
 
     # Create sensor entities from device
     add_entities([
-        MideaTemperatureSensor(
-            device, "Indoor Temperature", "indoor_temperature"),
-        MideaTemperatureSensor(
-            device, "Outdoor Temperature", "outdoor_temperature"),
+        MideaTemperatureSensor(device, "indoor_temperature"),
+        MideaTemperatureSensor(device, "outdoor_temperature"),
     ])
+
 
 class MideaTemperatureSensor(RestoreSensor):
     """Temperature sensor for Midea AC."""
 
-    def __init__(self, device, friendly_name, prop):
+    def __init__(self, device, prop):
         self._device = device
-        self._name = friendly_name
         self._prop = prop
         self._native_value = None
 
@@ -74,8 +73,7 @@ class MideaTemperatureSensor(RestoreSensor):
 
     @property
     def name(self) -> str:
-        # TODO better names
-        return f"{self._name}"
+        return f"{DOMAIN}_{self._prop}"
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -1,0 +1,92 @@
+"""Platform for sensor integration."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorStateClass,
+    RestoreSensor,
+)
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+import logging
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None
+) -> None:
+    """Setup the sensor platform for Midea Smart AC."""
+
+    # Only setup via discovery
+    if discovery_info is None:
+        return
+
+    _LOGGER.info("Setting up sensor platform.")
+
+    device = hass.data[DOMAIN]["device"]
+
+    add_entities([
+        MideaTemperatureSensor(
+            device, "Indoor Temperature", "indoor_temperature"),
+        MideaTemperatureSensor(
+            device, "Outdoor Temperature", "outdoor_temperature"),
+    ])
+
+
+class MideaTemperatureSensor(RestoreSensor):
+    """Temperature sensor for Midea AC."""
+
+    def __init__(self, device, friendly_name, prop):
+        self._device = device
+        self._name = friendly_name
+        self._prop = prop
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        if (last_sensor_data := await self.async_get_last_sensor_data()) is None:
+            return
+
+        # Restore previous native value
+        self._native_value = last_sensor_data.native_value
+
+    async def async_update(self):
+        # Grab the property from the device
+        self._native_value = getattr(self._device, self._prop)
+
+    @property
+    def name(self) -> str:
+        return f"{self._name}"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device.id}-{self._prop}"
+
+    @property
+    def available(self) -> bool:
+        return self._device.online
+
+    @property
+    def device_class(self):
+        return SensorDeviceClass.TEMPERATURE
+
+    @property
+    def state_class(self):
+        return SensorStateClass.MEASUREMENT
+
+    @property
+    def native_unit_of_measurement(self):
+        return TEMP_CELSIUS
+
+    @property
+    def native_value(self):
+        return self._native_value

--- a/custom_components/midea_ac/strings.json
+++ b/custom_components/midea_ac/strings.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configure Midea Smart AC Device",
+        "description": "Enter information for your device.",
+        "data": {
+          "id": "ID",
+          "host": "Host",
+          "port": "Port",
+          "token": "Token",
+          "k1": "K1",
+          "prompt_tone": "Prompt Tone",
+          "temp_step": "Temperature Step",
+          "include_off_as_state": "Include \"Off\" State",
+          "use_fan_only_workaround": "Use Fan-only Workaround",
+          "keep_last_known_online_state": "Keep Last Known State"
+        },
+        "data_description": {
+          "token": "Token for V3 devices",
+          "k1": "K1 for V3 devices",
+          "prompt_tone": "Enable the beep when sending commands",
+          "temp_step": "Step size for temperature set point"
+        }
+      }
+    },
+    "abort":{
+      "already_configured": "The device ID has already been configured."
+    },
+    "error":{
+      "connection":"A connection could not be made with these settings."
+    }
+  }
+}

--- a/custom_components/midea_ac/strings.json
+++ b/custom_components/midea_ac/strings.json
@@ -28,7 +28,25 @@
       "already_configured": "The device ID has already been configured."
     },
     "error":{
-      "connection":"A connection could not be made with these settings."
+      "cannot_connect":"A connection could not be made with these settings."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options for Midea Smart AC Device",
+        "data": {
+          "prompt_tone": "Prompt Tone",
+          "temp_step": "Temperature Step",
+          "include_off_as_state": "Include \"Off\" State",
+          "use_fan_only_workaround": "Use Fan-only Workaround",
+          "keep_last_known_online_state": "Keep Last Known State"
+        },
+        "data_description": {
+          "prompt_tone": "Enable the beep when sending commands",
+          "temp_step": "Step size for temperature set point"
+        }
+      }
     }
   }
 }

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -1,0 +1,1 @@
+../strings.json

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -1,1 +1,0 @@
-../strings.json

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -1,0 +1,52 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Configure Midea Smart AC Device",
+        "description": "Enter information for your device.",
+        "data": {
+          "id": "ID",
+          "host": "Host",
+          "port": "Port",
+          "token": "Token",
+          "k1": "K1",
+          "prompt_tone": "Prompt Tone",
+          "temp_step": "Temperature Step",
+          "include_off_as_state": "Include \"Off\" State",
+          "use_fan_only_workaround": "Use Fan-only Workaround",
+          "keep_last_known_online_state": "Keep Last Known State"
+        },
+        "data_description": {
+          "token": "Token for V3 devices",
+          "k1": "K1 for V3 devices",
+          "prompt_tone": "Enable the beep when sending commands",
+          "temp_step": "Step size for temperature set point"
+        }
+      }
+    },
+    "abort":{
+      "already_configured": "The device ID has already been configured."
+    },
+    "error":{
+      "cannot_connect":"A connection could not be made with these settings."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options for Midea Smart AC Device",
+        "data": {
+          "prompt_tone": "Prompt Tone",
+          "temp_step": "Temperature Step",
+          "include_off_as_state": "Include \"Off\" State",
+          "use_fan_only_workaround": "Use Fan-only Workaround",
+          "keep_last_known_online_state": "Keep Last Known State"
+        },
+        "data_description": {
+          "prompt_tone": "Enable the beep when sending commands",
+          "temp_step": "Step size for temperature set point"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a major overhaul of the integration to support GUI configuration, registering devices and adding additional entities to expose temperature sensors.

Closes #153

Support for legacy YAML configuration was **removed**. Devices are now added using the GUI, which also supports the options flow for changing (some) device options.

This PR is based on #165 but could be modified to support msmart 0.2.3