### PR TITLE
fan_mode: Fix key error when calling from HomeKit

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -239,6 +239,8 @@ class MideaClimateACDevice(ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode) -> None:
         """Set fan mode."""
+        """Fix key error when calling from HomeKit"""
+        fan_mode = fan_mode.capitalize()
         self._device.fan_speed = ac.fan_speed_enum[fan_mode]
         self._changed = True
         await self.apply_changes()


### PR DESCRIPTION
HomeKit calls will using fan mode with lower case key, like "low", "high"
Try to fix this problem