### PR TITLE
Improve backwards compatibility with older msmart versions

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -4,7 +4,7 @@
         "version": "0.2.4",
         "documentation": "https://github.com/mac-zhou/midea-ac-py",
         "issue_tracker": "https://github.com/mac-zhou/midea-ac-py/issues",
-        "requirements": ["msmart==0.2.4", "pycryptodome", "pycryptodomex", "click"],
+        "requirements": ["msmart>=0.2.3", "pycryptodome", "pycryptodomex", "click"],
         "dependencies": [],
         "codeowners": ["@mac-zhou"],
         "iot_class": "local_polling",


### PR DESCRIPTION
Use `getattr` calls to fetch various properties from the device which don't exist in msmart 0.2.3.